### PR TITLE
Broadcast queue updates on ticket creation

### DIFF
--- a/src/composables/useQueue.js
+++ b/src/composables/useQueue.js
@@ -45,6 +45,8 @@ export function useQueue(channelId) {
     myNumber.value = newNumber
     // Durumu tüm cihazlarla senkronize et.
     syncStateFromStorage()
+    // Diğer sekmelere yeni bir numara alındığını bildir.
+    channel.postMessage({ type: 'TAKE', number: newNumber })
     console.log('✅ useQueue: Sıra numarası verildi:', myNumber.value)
   }
 


### PR DESCRIPTION
## Summary
- notify other tabs when a new ticket number is issued to keep waiting counts in sync

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 8 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68989c4cf71c83298cc23b897ed5e98e